### PR TITLE
Revert "build(deps): bump androidx.core:core-ktx from 1.13.1 to 1.15.0 (#9)"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.7.3"
 kotlin = "2.1.0"
-coreKtx = "1.15.0"
+coreKtx = "1.13.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"


### PR DESCRIPTION
This reverts commit 6aca47c3faf59146b0ecb87dad9fd8884384824b.

'androidx.core:core-ktx:1.15.0' 依赖要求应用的 compileSdk 至少是 35 （Android 15），否则会编译失败，暂时不考虑升级